### PR TITLE
InputTrimModule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /node_modules/
+*ngfactory.ts
+*ngsummary.json
 *.log
 .idea
 dist

--- a/README.md
+++ b/README.md
@@ -7,21 +7,24 @@
 
 ## Usage 
 
-1. Install the directive.
+1. Install `ng2-trim-directive`.
 
   ```bash
     npm i ng2-trim-directive
   ```
 
-2. Add the directive to your module 'declarations' section.
+2. Import `InputTrimModule` to your Angular module.
 
-  ```typescript
-    @NgModule( {
-      ...
-      declarations: [ ..., InputTrimDirective ],
-      ...
-    } )
-  ```
+```typescript
+import { InputTrimModule } from 'ng2-trim-directive';
+@NgModule({
+  imports: [
+    ...
+    InputTrimModule,
+    ...
+  ],
+  ...
+```
 
 3. Add the "trim" attribute to a text input element.
   ```html

--- a/example/src/app/app.module.ts
+++ b/example/src/app/app.module.ts
@@ -2,13 +2,16 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { FormsModule } from '@angular/forms';
-import { InputTrimDirective } from '../../../src/input-trim.directive';
+import { InputTrimModule } from '../../../src/';
 
 @NgModule( {
-  imports     : [BrowserModule, FormsModule],
+  imports     : [
+    BrowserModule,
+    FormsModule,
+    InputTrimModule,
+  ],
   declarations: [
     AppComponent,
-    InputTrimDirective
   ],
   bootstrap   : [AppComponent]
 } )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"           : "ng2-trim-directive",
-  "version"        : "1.0.5",
+  "version"        : "2.0.0",
   "author"         : "Alexander Ein (@alexanderein)",
   "license"        : "MIT",
   "repository"     : {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "LICENSE"
   ],
   "scripts"        : {
-    "eg:build": "ng build --app 0",
-    "eg:serve": "ng serve --app 0",
-    "build"   : "ngc --project ./tsconfig.json",
-    "test"    : "ng test"
+    "eg:build"  : "ng build --app 0",
+    "eg:serve"  : "ng serve --app 0",
+    "build"     : "ngc --project ./tsconfig.json",
+    "test"      : "ng test",
+    "prepublish": "npm run build"
   },
   "devDependencies": {
     "@angular/cli"                     : "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "trim",
     "javascript"
   ],
-  "main"           : "dist/input-trim.directive.js",
-  "types"          : "dist/input-trim.directive.d.ts",
+  "main"           : "dist/index.js",
+  "types"          : "dist/index.d.ts",
   "files"          : [
     "dist",
     "LICENSE"
@@ -27,7 +27,7 @@
   "scripts"        : {
     "eg:build": "ng build --app 0",
     "eg:serve": "ng serve --app 0",
-    "build"   : "tsc --project ./tsconfig.json",
+    "build"   : "ngc --project ./tsconfig.json",
     "test"    : "ng test"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from './input-trim.directive';
+export * from './input-trim.module';

--- a/src/input-trim.module.ts
+++ b/src/input-trim.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+
+import { InputTrimDirective } from './input-trim.directive';
+
+@NgModule({
+  imports: [],
+  exports: [InputTrimDirective],
+  declarations: [InputTrimDirective],
+  providers: [],
+})
+export class InputTrimModule { }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,8 @@
   "exclude"        : [
     "node_modules",
     "**/*.spec.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }


### PR DESCRIPTION
Added `InputTrimModule` to prevent redeclaration of directives inside the users' code.

```
ERROR in type InputTrimDirective in ... is part of the declarations of 2 modules
```

Updated README.md with the proposed import, as well as the example version. The usage still remains the same.