### PR TITLE
Remove `-D` flag from yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Play with the directive here [https://anein.github.io/angular2-trim-directive/](
   or using **Yarn**
   
   ```bash
-    yarn add ng2-trim-directive -D
+    yarn add ng2-trim-directive
   ```
   
 2. Import `InputTrimModule` to your Angular module.


### PR DESCRIPTION
There is no need to add this package as a dev dependency. Plus, the instructions don't have such a flag in the `npm` version, so I am not sure why it's inconsistent in the `yarn` version.